### PR TITLE
Feature/directory api

### DIFF
--- a/src/main/java/home/example/echoLog/controller/api/CmdAPI.java
+++ b/src/main/java/home/example/echoLog/controller/api/CmdAPI.java
@@ -46,23 +46,28 @@ public class CmdAPI {
         if (parsedCommand.containsKey(ExecType.ECHO)) {
             response.put("type", ExecType.ECHO);
             response.put("message", parsedCommand.get(ExecType.ECHO));
-        } else if (parsedCommand.containsKey(ExecType.MKDIR)) {
+        }
+        else if (parsedCommand.containsKey(ExecType.MKDIR)) {
             mkdirService.addDirectory(parsedCommand.get(ExecType.MKDIR));
             response.put("type", ExecType.MKDIR);
             response.put("message", "Directory created: " + parsedCommand.get(ExecType.MKDIR));
-        } else if (parsedCommand.containsKey(ExecType.CD)) {
+        }
+        else if (parsedCommand.containsKey(ExecType.CD)) {
             response.put("currentPath", cdService.changeDirectory(parsedCommand.get(ExecType.CD)));
             response.put("type", ExecType.CD);
             response.put("message", "Changed directory to: " + parsedCommand.get(ExecType.CD));
-        } else if (parsedCommand.containsKey(ExecType.LS)) {
+        }
+        else if (parsedCommand.containsKey(ExecType.LS)) {
             response.put("directories", lsService.listDirectories(parsedCommand.get(ExecType.LS)));
             response.put("type", ExecType.LS);
             response.put("message", "Listed directories at: " + parsedCommand.get(ExecType.LS));
-        } else if (parsedCommand.containsKey(ExecType.TREE)) {
+        }
+        else if (parsedCommand.containsKey(ExecType.TREE)) {
             response.put("tree", treeService.getTree(parsedCommand.get(ExecType.TREE)));
             response.put("type", ExecType.TREE);
             response.put("message", "Tree structure at: " + parsedCommand.get(ExecType.TREE));
-        } else {
+        }
+        else {
             return ResponseEntity.badRequest().body(null);
         }
         return ResponseEntity.ok(response);

--- a/src/main/java/home/example/echoLog/controller/api/CmdAPI.java
+++ b/src/main/java/home/example/echoLog/controller/api/CmdAPI.java
@@ -1,0 +1,70 @@
+package home.example.echoLog.controller.api;
+
+import home.example.echoLog.model.dto.CommandRequestDTO;
+import home.example.echoLog.model.type.ExecType;
+import home.example.echoLog.service.cmd.CdService;
+import home.example.echoLog.service.cmd.LsService;
+import home.example.echoLog.service.cmd.MkdirService;
+import home.example.echoLog.service.cmd.TreeService;
+import home.example.echoLog.util.CommandParser;
+import org.json.simple.JSONObject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+public class CmdAPI {
+
+    private final CommandParser commandParser;
+    private final CdService cdService;
+    private final MkdirService mkdirService;
+    private final LsService lsService;
+    private final TreeService treeService;
+    public CmdAPI(CommandParser commandParser,
+                  CdService cdService,
+                  MkdirService mkdirService,
+                  LsService lsService,
+                  TreeService treeService) {
+        this.commandParser = commandParser;
+        this.cdService = cdService;
+        this.mkdirService = mkdirService;
+        this.lsService = lsService;
+        this.treeService = treeService;
+    }
+
+    @PostMapping("/api/cmd") // parameter path, command to execute
+    public ResponseEntity<JSONObject> executeCommand(
+            @RequestBody CommandRequestDTO commandRequestDTO
+            ) {
+        JSONObject response = new JSONObject();
+        String path = commandRequestDTO.getPath();
+        String command = commandRequestDTO.getCommand();
+        Map<ExecType, String> parsedCommand = commandParser.parseCommand(path, command);
+        if (parsedCommand.containsKey(ExecType.ECHO)) {
+            response.put("type", ExecType.ECHO);
+            response.put("message", parsedCommand.get(ExecType.ECHO));
+        } else if (parsedCommand.containsKey(ExecType.MKDIR)) {
+            mkdirService.addDirectory(parsedCommand.get(ExecType.MKDIR));
+            response.put("type", ExecType.MKDIR);
+            response.put("message", "Directory created: " + parsedCommand.get(ExecType.MKDIR));
+        } else if (parsedCommand.containsKey(ExecType.CD)) {
+            response.put("currentPath", cdService.changeDirectory(parsedCommand.get(ExecType.CD)));
+            response.put("type", ExecType.CD);
+            response.put("message", "Changed directory to: " + parsedCommand.get(ExecType.CD));
+        } else if (parsedCommand.containsKey(ExecType.LS)) {
+            response.put("directories", lsService.listDirectories(parsedCommand.get(ExecType.LS)));
+            response.put("type", ExecType.LS);
+            response.put("message", "Listed directories at: " + parsedCommand.get(ExecType.LS));
+        } else if (parsedCommand.containsKey(ExecType.TREE)) {
+            response.put("tree", treeService.getTree(parsedCommand.get(ExecType.TREE)));
+            response.put("type", ExecType.TREE);
+            response.put("message", "Tree structure at: " + parsedCommand.get(ExecType.TREE));
+        } else {
+            return ResponseEntity.badRequest().body(null);
+        }
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/home/example/echoLog/controller/api/HistoryAPI.java
+++ b/src/main/java/home/example/echoLog/controller/api/HistoryAPI.java
@@ -1,0 +1,30 @@
+package home.example.echoLog.controller.api;
+
+import org.json.simple.JSONObject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HistoryAPI {
+
+    @GetMapping("/api/history") // Endpoint to retrieve command history
+    public ResponseEntity<JSONObject> getHistory(
+        @RequestParam (value = "path", required = false) String path,
+        @RequestParam (value = "limit", required = false, defaultValue = "10") int limit,
+        @RequestParam (value = "offset", required = false, defaultValue = "0") int offset
+    ){
+        JSONObject response = new JSONObject();
+        try {
+            // Simulate fetching command history
+            String history = "Command history for path: " + path + ", limit: " + limit + ", offset: " + offset; // Replace with actual history retrieval logic
+            response.put("status", "success");
+            response.put("history", history);
+        } catch (Exception e) {
+            response.put("status", "error");
+            response.put("message", e.getMessage());
+        }
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/home/example/echoLog/controller/api/StreamAPI.java
+++ b/src/main/java/home/example/echoLog/controller/api/StreamAPI.java
@@ -1,0 +1,31 @@
+package home.example.echoLog.controller.api;
+
+import org.json.simple.JSONObject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class StreamAPI {
+    // server sent events (SSE) endpoint for streaming logs
+    // This is a placeholder for the actual implementation of the streaming API.
+    // You can implement methods to handle streaming logs, such as:
+    // - @GetMapping("/api/stream/logs") to stream logs in real-time
+
+    @GetMapping("/api/stream/logs")
+    public ResponseEntity<JSONObject> streamLogs() {
+        // Placeholder for streaming logs logic
+        // In a real implementation, you would return a stream of log data
+        JSONObject response = new JSONObject();
+        try {
+            // Simulate streaming logs
+            String logData = "Streaming logs..."; // Replace with actual log streaming logic
+            response.put("status", "success");
+            response.put("logs", logData);
+        } catch (Exception e) {
+            response.put("status", "error");
+            response.put("message", e.getMessage());
+        }
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/home/example/echoLog/mapper/DirectoryMapper.java
+++ b/src/main/java/home/example/echoLog/mapper/DirectoryMapper.java
@@ -1,0 +1,16 @@
+package home.example.echoLog.mapper;
+
+import home.example.echoLog.model.Directory;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+import java.util.Optional;
+
+@Mapper
+public interface DirectoryMapper {
+    Directory getRootDirectory();
+    Optional<Directory> getDirectoryByName(Directory directory);
+    Optional<Directory> getDirectoryById(Long dir_id);
+    void addDirectory(Directory directory);
+    List<Directory> getChildrenDirectories(Long parent_id);
+}

--- a/src/main/java/home/example/echoLog/model/Directory.java
+++ b/src/main/java/home/example/echoLog/model/Directory.java
@@ -1,0 +1,15 @@
+package home.example.echoLog.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class Directory {
+    private Long dir_id;
+    private String name;
+    private Long parent_id;
+    private LocalDateTime created_at;
+}

--- a/src/main/java/home/example/echoLog/model/EchoLog.java
+++ b/src/main/java/home/example/echoLog/model/EchoLog.java
@@ -1,0 +1,13 @@
+package home.example.echoLog.model;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class EchoLog {
+    private Long log_seq;
+    private Long dir_id;
+    private String message;
+    private LocalDateTime created_at;
+}

--- a/src/main/java/home/example/echoLog/model/dto/CommandRequestDTO.java
+++ b/src/main/java/home/example/echoLog/model/dto/CommandRequestDTO.java
@@ -1,0 +1,9 @@
+package home.example.echoLog.model.dto;
+
+import lombok.Data;
+
+@Data
+public class CommandRequestDTO {
+    private String path;
+    private String command;
+}

--- a/src/main/java/home/example/echoLog/model/type/ExecType.java
+++ b/src/main/java/home/example/echoLog/model/type/ExecType.java
@@ -1,0 +1,14 @@
+package home.example.echoLog.model.type;
+
+public enum ExecType {
+    ECHO("echo"),
+    MKDIR("mkdir"),
+    CD("cd"),
+    LS("ls"),
+    TREE("tree");
+
+    private final String type;
+    ExecType(String type) {
+        this.type = type;
+    }
+}

--- a/src/main/java/home/example/echoLog/service/HistoryGetService.java
+++ b/src/main/java/home/example/echoLog/service/HistoryGetService.java
@@ -1,0 +1,7 @@
+package home.example.echoLog.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class HistoryGetService {
+}

--- a/src/main/java/home/example/echoLog/service/StreamService.java
+++ b/src/main/java/home/example/echoLog/service/StreamService.java
@@ -1,0 +1,7 @@
+package home.example.echoLog.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class StreamService {
+}

--- a/src/main/java/home/example/echoLog/service/cmd/CdService.java
+++ b/src/main/java/home/example/echoLog/service/cmd/CdService.java
@@ -18,8 +18,7 @@ public class CdService {
             throw new IllegalArgumentException("Path cannot be null or empty");
         }
         String[] paths = path.split("/");
-        Directory current = directoryMapper.getDirectoryByName(rootDirectory())
-                .orElseThrow(() -> new IllegalArgumentException("Root directory does not exist"));
+        Directory current = rootDirectory();
         for(int i = 1; i < paths.length - 1; i++) {
             String p = paths[i];
             Directory parameter = Directory.builder()

--- a/src/main/java/home/example/echoLog/service/cmd/CdService.java
+++ b/src/main/java/home/example/echoLog/service/cmd/CdService.java
@@ -1,0 +1,41 @@
+package home.example.echoLog.service.cmd;
+
+import home.example.echoLog.mapper.DirectoryMapper;
+import home.example.echoLog.model.Directory;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class CdService {
+    private final DirectoryMapper directoryMapper;
+    public CdService(DirectoryMapper directoryMapper) {
+        this.directoryMapper = directoryMapper;
+    }
+
+    public Directory changeDirectory(String path) {
+        if(path == null || path.isEmpty()) {
+            throw new IllegalArgumentException("Path cannot be null or empty");
+        }
+        String[] paths = path.split("/");
+        Directory current = directoryMapper.getDirectoryByName(rootDirectory())
+                .orElseThrow(() -> new IllegalArgumentException("Root directory does not exist"));
+        for(int i = 1; i < paths.length - 1; i++) {
+            String p = paths[i];
+            Directory parameter = Directory.builder()
+                    .name(p)
+                    .parent_id(current.getDir_id())
+                    .build();
+            Optional<Directory> next = directoryMapper.getDirectoryByName(parameter);
+            if (!next.isPresent()) {
+                throw new IllegalArgumentException("Directory does not exist: " + p);
+            }
+            current = next.get();
+        }
+        return current;
+    }
+
+    private Directory rootDirectory() {
+        return directoryMapper.getRootDirectory();
+    }
+}

--- a/src/main/java/home/example/echoLog/service/cmd/EchoService.java
+++ b/src/main/java/home/example/echoLog/service/cmd/EchoService.java
@@ -1,0 +1,7 @@
+package home.example.echoLog.service.cmd;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class EchoService {
+}

--- a/src/main/java/home/example/echoLog/service/cmd/LsService.java
+++ b/src/main/java/home/example/echoLog/service/cmd/LsService.java
@@ -21,9 +21,8 @@ public class LsService {
             throw new IllegalArgumentException("Path cannot be null or empty");
         }
         String[] paths = path.split("/");
-        Directory current = directoryMapper.getDirectoryByName(rootDirectory())
-                .orElseThrow(() -> new IllegalArgumentException("Root directory does not exist"));
-        for(int i = 1; i < paths.length - 1; i++) {
+        Directory current = rootDirectory();
+        for(int i = 1; i < paths.length; i++) {
             String p = paths[i];
             Directory parameter = Directory.builder()
                     .name(p)

--- a/src/main/java/home/example/echoLog/service/cmd/LsService.java
+++ b/src/main/java/home/example/echoLog/service/cmd/LsService.java
@@ -1,0 +1,44 @@
+package home.example.echoLog.service.cmd;
+
+import home.example.echoLog.mapper.DirectoryMapper;
+import home.example.echoLog.model.Directory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class LsService {
+    private final DirectoryMapper directoryMapper;
+    public LsService(DirectoryMapper directoryMapper) {
+        this.directoryMapper = directoryMapper;
+    }
+
+    public List<Directory> listDirectories(String path) {
+        if (path == null || path.isEmpty()) {
+            throw new IllegalArgumentException("Path cannot be null or empty");
+        }
+        String[] paths = path.split("/");
+        Directory current = directoryMapper.getDirectoryByName(rootDirectory())
+                .orElseThrow(() -> new IllegalArgumentException("Root directory does not exist"));
+        for(int i = 1; i < paths.length - 1; i++) {
+            String p = paths[i];
+            Directory parameter = Directory.builder()
+                    .name(p)
+                    .parent_id(current.getDir_id())
+                    .build();
+            Optional<Directory> next = directoryMapper.getDirectoryByName(parameter);
+            if (!next.isPresent()) {
+                throw new IllegalArgumentException("Directory does not exist: " + p);
+            }
+            current = next.get();
+        }
+        return  directoryMapper.getChildrenDirectories(current.getDir_id());
+    }
+
+    private Directory rootDirectory() {
+        return directoryMapper.getRootDirectory();
+    }
+}

--- a/src/main/java/home/example/echoLog/service/cmd/MkdirService.java
+++ b/src/main/java/home/example/echoLog/service/cmd/MkdirService.java
@@ -1,0 +1,47 @@
+package home.example.echoLog.service.cmd;
+
+import home.example.echoLog.mapper.DirectoryMapper;
+import home.example.echoLog.model.Directory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+public class MkdirService {
+    private final DirectoryMapper directoryMapper;
+    public MkdirService(DirectoryMapper directoryMapper) {
+        this.directoryMapper = directoryMapper;
+    }
+    @Transactional
+    public void addDirectory(String path) {
+        if (path == null || path.isEmpty()) {
+            throw new IllegalArgumentException("Path cannot be null or empty");
+        }
+        String[] paths = path.split("/");
+        Directory current = directoryMapper.getDirectoryByName(rootDirectory())
+                .orElseThrow(() -> new IllegalArgumentException("Root directory does not exist"));
+        for(int i = 1; i < paths.length - 2; i++) {
+            String p = paths[i];
+            Directory parameter = Directory.builder()
+                    .name(p)
+                    .parent_id(current.getDir_id())
+                    .build();
+            Optional<Directory> next = directoryMapper.getDirectoryByName(parameter);
+            if (!next.isPresent()) {
+                throw new IllegalArgumentException("Directory does not exist: " + p);
+            }
+            current = next.get();
+        }
+        String lastPath = paths[paths.length - 1];
+        Directory newDirectory = Directory.builder()
+                .name(lastPath)
+                .parent_id(current.getDir_id())
+                .build();
+        directoryMapper.addDirectory(newDirectory);
+    }
+
+    private Directory rootDirectory() {
+        return directoryMapper.getRootDirectory();
+    }
+}

--- a/src/main/java/home/example/echoLog/service/cmd/MkdirService.java
+++ b/src/main/java/home/example/echoLog/service/cmd/MkdirService.java
@@ -19,9 +19,8 @@ public class MkdirService {
             throw new IllegalArgumentException("Path cannot be null or empty");
         }
         String[] paths = path.split("/");
-        Directory current = directoryMapper.getDirectoryByName(rootDirectory())
-                .orElseThrow(() -> new IllegalArgumentException("Root directory does not exist"));
-        for(int i = 1; i < paths.length - 2; i++) {
+        Directory current = rootDirectory();
+        for(int i = 1; i < paths.length - 1; i++) {
             String p = paths[i];
             Directory parameter = Directory.builder()
                     .name(p)

--- a/src/main/java/home/example/echoLog/service/cmd/TreeService.java
+++ b/src/main/java/home/example/echoLog/service/cmd/TreeService.java
@@ -25,8 +25,7 @@ public class TreeService {
             throw new IllegalArgumentException("Path cannot be null or empty");
         }
         String[] paths = path.split("/");
-        Directory current = directoryMapper.getDirectoryByName(directoryMapper.getRootDirectory())
-                .orElseThrow(() -> new IllegalArgumentException("Root directory does not exist"));
+        Directory current = directoryMapper.getRootDirectory();
         for (int i = 1; i < paths.length - 1; i++) {
             String p = paths[i];
             Directory parameter = Directory.builder()
@@ -40,11 +39,13 @@ public class TreeService {
     }
 
     private JSONObject buildTreeJSON(Long dir_id, Integer limit) {
+        JSONObject node = new JSONObject();
+        if(limit == 0) {
+            return node; // Return empty node if limit is reached
+        }
         if (dir_id == null) {
             throw new IllegalArgumentException("Directory ID cannot be null");
         }
-        int paramLimit = limit != null ? limit : 3; // Default limit if not provided
-        JSONObject node = new JSONObject();
         Directory directory = directoryMapper.getDirectoryById(dir_id)
                 .orElseThrow(() -> new IllegalArgumentException("Directory does not exist: " + dir_id));
         List<Directory> childrenDirectories = directoryMapper.getChildrenDirectories(dir_id);
@@ -56,7 +57,7 @@ public class TreeService {
             node.put("name", directory.getName());
             node.put("dir_id", directory.getDir_id());
             node.put("children", childrenDirectories.stream()
-                    .map(child -> buildTreeJSON(child.getDir_id(), paramLimit-1))
+                    .map(child -> buildTreeJSON(child.getDir_id(), limit-1))
                     .collect(Collectors.toList()));
         }
         return node;

--- a/src/main/java/home/example/echoLog/service/cmd/TreeService.java
+++ b/src/main/java/home/example/echoLog/service/cmd/TreeService.java
@@ -1,0 +1,64 @@
+package home.example.echoLog.service.cmd;
+
+import home.example.echoLog.mapper.DirectoryMapper;
+import home.example.echoLog.model.Directory;
+import org.json.simple.JSONObject;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class TreeService {
+    private final DirectoryMapper directoryMapper;
+    public TreeService(DirectoryMapper directoryMapper) {
+        this.directoryMapper = directoryMapper;
+    }
+
+    public JSONObject getTree(String path) {
+        Directory directory = resolvePath(path);
+        return buildTreeJSON(directory.getDir_id(), 3);
+    }
+
+    private Directory resolvePath(String path) {
+        if (path == null || path.isEmpty()) {
+            throw new IllegalArgumentException("Path cannot be null or empty");
+        }
+        String[] paths = path.split("/");
+        Directory current = directoryMapper.getDirectoryByName(directoryMapper.getRootDirectory())
+                .orElseThrow(() -> new IllegalArgumentException("Root directory does not exist"));
+        for (int i = 1; i < paths.length - 1; i++) {
+            String p = paths[i];
+            Directory parameter = Directory.builder()
+                    .name(p)
+                    .parent_id(current.getDir_id())
+                    .build();
+            current = directoryMapper.getDirectoryByName(parameter)
+                    .orElseThrow(() -> new IllegalArgumentException("Directory does not exist: " + p));
+        }
+        return current;
+    }
+
+    private JSONObject buildTreeJSON(Long dir_id, Integer limit) {
+        if (dir_id == null) {
+            throw new IllegalArgumentException("Directory ID cannot be null");
+        }
+        int paramLimit = limit != null ? limit : 3; // Default limit if not provided
+        JSONObject node = new JSONObject();
+        Directory directory = directoryMapper.getDirectoryById(dir_id)
+                .orElseThrow(() -> new IllegalArgumentException("Directory does not exist: " + dir_id));
+        List<Directory> childrenDirectories = directoryMapper.getChildrenDirectories(dir_id);
+        if( childrenDirectories.isEmpty()) {
+            node.put("name", directory.getName());
+            node.put("dir_id", directory.getDir_id());
+            node.put("children", childrenDirectories);
+        }else{
+            node.put("name", directory.getName());
+            node.put("dir_id", directory.getDir_id());
+            node.put("children", childrenDirectories.stream()
+                    .map(child -> buildTreeJSON(child.getDir_id(), paramLimit-1))
+                    .collect(Collectors.toList()));
+        }
+        return node;
+    }
+}

--- a/src/main/java/home/example/echoLog/util/CommandParser.java
+++ b/src/main/java/home/example/echoLog/util/CommandParser.java
@@ -1,0 +1,68 @@
+package home.example.echoLog.util;
+
+import home.example.echoLog.model.type.ExecType;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class CommandParser {
+
+    // /echo "hello world"
+    // /mkdir "/home/user/newfolder"
+    // /cd "/home/user/documents"
+    public Map<ExecType, String> parseCommand(String path, String command) {
+        if (command == null || command.isEmpty()) {
+            throw new IllegalArgumentException("Command cannot be null or empty");
+        }
+        command = command.trim();
+        Map<ExecType, String> result = new HashMap<>();
+        String[] commands = command.split("\\s+");
+        String exec = commands[0];
+        String arg = String.join(" ", java.util.Arrays.copyOfRange(commands, 1, commands.length));
+        if (arg.startsWith("\"") && arg.endsWith("\"")) {
+            arg = arg.substring(1, arg.length() - 1); // remove quotes
+        }
+        if (arg.startsWith("'") && arg.endsWith("'")) {
+            arg = arg.substring(1, arg.length() - 1); // remove single quotes
+        }
+
+
+        if(!exec.startsWith("/")) { // default command = "echo"
+            result.put(ExecType.ECHO, arg);
+        }
+        else if (exec.equals("/echo")) {
+            result.put(ExecType.ECHO, arg);
+        } else if(directoryCommands().contains(exec)) {
+            if (arg.startsWith("/")) {
+                arg = path + arg; // prepend path if argument starts with "/"
+            } else if (!arg.startsWith("~") && !arg.startsWith("/")) {
+                arg = path + "/" + arg; // prepend path if argument does not start with "~" or "/"
+            }
+            if (exec.equals("/mkdir")) {
+                result.put(ExecType.MKDIR, arg);
+            } else if (exec.equals("/cd")) {
+                result.put(ExecType.CD, arg);
+            } else if (exec.equals("/ls")) {
+                result.put(ExecType.LS, path);
+            } else if (exec.equals("/tree")) {
+                result.put(ExecType.TREE, path);
+            }
+        } else {
+            throw new IllegalArgumentException("Unknown command: " + exec);
+        }
+        return result;
+    }
+
+    private List<String> directoryCommands() {
+        List<String> commands = new ArrayList<>();
+        commands.add("/mkdir");
+        commands.add("/cd");
+        commands.add("/ls");
+        commands.add("/tree");
+        return commands;
+    }
+}

--- a/src/main/java/home/example/echoLog/util/CommandParser.java
+++ b/src/main/java/home/example/echoLog/util/CommandParser.java
@@ -3,10 +3,7 @@ package home.example.echoLog.util;
 import home.example.echoLog.model.type.ExecType;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @Component
 public class CommandParser {
@@ -54,13 +51,15 @@ public class CommandParser {
         return result;
     }
 
-    private List<String> directoryCommands() {
-        List<String> commands = new ArrayList<>();
-        commands.add("/mkdir");
-        commands.add("/cd");
-        commands.add("/ls");
-        commands.add("/tree");
-        return commands;
+    private Set<String> directoryCommands() {
+        Set<String> commandSet = new HashSet<>();
+        commandSet.add("/echo");
+        commandSet.add("/mkdir");
+        commandSet.add("/cd");
+        commandSet.add("/ls");
+        commandSet.add("/tree");
+
+        return commandSet;
     }
 
     public String getArgs(String path, String arg){

--- a/src/main/java/home/example/echoLog/util/CommandParser.java
+++ b/src/main/java/home/example/echoLog/util/CommandParser.java
@@ -37,11 +37,8 @@ public class CommandParser {
         else if (exec.equals("/echo")) {
             result.put(ExecType.ECHO, arg);
         } else if(directoryCommands().contains(exec)) {
-            if (arg.startsWith("/")) {
-                arg = path + arg; // prepend path if argument starts with "/"
-            } else if (!arg.startsWith("~") && !arg.startsWith("/")) {
-                arg = path + "/" + arg; // prepend path if argument does not start with "~" or "/"
-            }
+            arg = getArgs(path, arg); // prepend path to argument
+
             if (exec.equals("/mkdir")) {
                 result.put(ExecType.MKDIR, arg);
             } else if (exec.equals("/cd")) {
@@ -64,5 +61,21 @@ public class CommandParser {
         commands.add("/ls");
         commands.add("/tree");
         return commands;
+    }
+
+    public String getArgs(String path, String arg){
+        if(path.endsWith("/")){
+            if(arg.startsWith("/")) {
+                return path + arg.substring(1); // prepend path if argument starts with "/"
+            }else{
+                return path + arg; // prepend path if argument does not start with "/"
+            }
+        }else{
+            if(arg.startsWith("/")) {
+                return path + arg; // prepend path if argument starts with "/"
+            }else{
+                return path + "/" + arg; // prepend path if argument does not start with "/"
+            }
+        }
     }
 }

--- a/src/main/resources/mapper/directoryMapper.xml
+++ b/src/main/resources/mapper/directoryMapper.xml
@@ -11,8 +11,18 @@
         <select id="getDirectoryByName"
                 parameterType="home.example.echoLog.model.Directory"
                 resultType="home.example.echoLog.model.Directory">
-            SELECT * FROM directories
-                     WHERE id = #{name} and parent_id = #{parent_id}
+            <![CDATA[
+                SELECT * FROM directories
+                         WHERE name = #{name}
+            ]]>
+                <choose>
+                   <when test="parent_id == null">
+                       AND parent_id IS NULL
+                    </when>
+                    <otherwise>
+                        AND parent_id = #{parent_id}
+                    </otherwise>
+                </choose>
         </select>
 
         <select id="getDirectoryById"

--- a/src/main/resources/mapper/directoryMapper.xml
+++ b/src/main/resources/mapper/directoryMapper.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+    <!DOCTYPE mapper
+      PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+      "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+    <mapper namespace="home.example.echoLog.mapper.DirectoryMapper">
+        <select id="getRootDirectory"
+                resultType="home.example.echoLog.model.Directory">
+            SELECT * FROM directories WHERE name = "" and parent_id IS NULL
+        </select>
+
+        <select id="getDirectoryByName"
+                parameterType="home.example.echoLog.model.Directory"
+                resultType="home.example.echoLog.model.Directory">
+            SELECT * FROM directories
+                     WHERE id = #{name} and parent_id = #{parent_id}
+        </select>
+
+        <select id="getDirectoryById"
+                parameterType="long"
+                resultType="home.example.echoLog.model.Directory">
+            SELECT * FROM directories WHERE dir_id = #{dir_id}
+        </select>
+
+        <insert id="addDirectory"
+                parameterType="home.example.echoLog.model.Directory">
+            INSERT INTO directories (name, parent_id, created_at)
+            VALUES (#{name}, #{parent_id}, NOW())
+        </insert>
+
+        <select id="getChildrenDirectories"
+                parameterType="long"
+                resultType="home.example.echoLog.model.Directory">
+            SELECT * FROM directories WHERE parent_id = #{parent_id}
+        </select>
+    </mapper>


### PR DESCRIPTION
This pull request introduces a new API for handling directory and log-related commands, along with the necessary backend infrastructure to support these operations. The changes include creating RESTful APIs, defining models and DTOs, implementing services for command execution, and adding a mapper for database interactions. Below is a summary of the most important changes:

### API Endpoints

* **`CmdAPI`**: Added a RESTful endpoint `/api/cmd` for executing commands such as `echo`, `mkdir`, `cd`, `ls`, and `tree`. The endpoint parses the command, executes it using the appropriate service, and returns a structured JSON response. (`[src/main/java/home/example/echoLog/controller/api/CmdAPI.javaR1-R75](diffhunk://#diff-392d52f49936fca020046ff28b0ecd8d9726446bc50b370bf224103075a50450R1-R75)`)
* **`HistoryAPI`**: Added an endpoint `/api/history` to fetch command history with support for query parameters like `path`, `limit`, and `offset`. Currently, this is a placeholder for actual history retrieval logic. (`[src/main/java/home/example/echoLog/controller/api/HistoryAPI.javaR1-R30](diffhunk://#diff-9c34d27c392d1581a471b60998f8efafdce322a16c36923b73a5a737d32df5e2R1-R30)`)
* **`StreamAPI`**: Added a placeholder endpoint `/api/stream/logs` for streaming logs using Server-Sent Events (SSE). (`[src/main/java/home/example/echoLog/controller/api/StreamAPI.javaR1-R31](diffhunk://#diff-b5bbd4f993d4a03f5d8db2550e1131f9cbe945d6f14763bc5feaf72722490ceaR1-R31)`)

### Backend Services

* **Command Execution Services**:
  * [`CdService`](diffhunk://#diff-89a60e7fc47cc3b4e52c3bddab6ebe54cbfa5c4f217161665b476ceee9710b58R1-R40): Implements logic for changing directories by traversing a directory tree. (`[src/main/java/home/example/echoLog/service/cmd/CdService.javaR1-R40](diffhunk://#diff-89a60e7fc47cc3b4e52c3bddab6ebe54cbfa5c4f217161665b476ceee9710b58R1-R40)`)
  * [`MkdirService`](diffhunk://#diff-53b4c3e8d134fabe543022324dc187234f9ab5de9a96b09156e34b29115e1942R1-R46): Implements logic for creating new directories in the directory tree. (`[src/main/java/home/example/echoLog/service/cmd/MkdirService.javaR1-R46](diffhunk://#diff-53b4c3e8d134fabe543022324dc187234f9ab5de9a96b09156e34b29115e1942R1-R46)`)
  * [`LsService`](diffhunk://#diff-8036138cd06dae97001eeeb58dc247b62adff66acf9edeb6e5dccf3c9c641e04R1-R43): Implements logic for listing child directories of a given directory. (`[src/main/java/home/example/echoLog/service/cmd/LsService.javaR1-R43](diffhunk://#diff-8036138cd06dae97001eeeb58dc247b62adff66acf9edeb6e5dccf3c9c641e04R1-R43)`)
  * [`TreeService`](diffhunk://#diff-7bb1baa1da91b47843e05985d2b0c55346676be9a59d6079e14b839a9fcd3cc5R1-R65): Implements logic for generating a JSON representation of a directory tree. (`[src/main/java/home/example/echoLog/service/cmd/TreeService.javaR1-R65](diffhunk://#diff-7bb1baa1da91b47843e05985d2b0c55346676be9a59d6079e14b839a9fcd3cc5R1-R65)`)
  * [`EchoService`](diffhunk://#diff-69f7cf9c91c01eb11b0d66b13b50954b65ff28719b417d30fcae208405e0eb5dR1-R7): Placeholder for handling `echo` commands. (`[src/main/java/home/example/echoLog/service/cmd/EchoService.javaR1-R7](diffhunk://#diff-69f7cf9c91c01eb11b0d66b13b50954b65ff28719b417d30fcae208405e0eb5dR1-R7)`)

* **Utility**:
  * [`CommandParser`](diffhunk://#diff-e73f81ae4b7c9f296dfa80d6e10829a8e5bf73469ff5f8b41f8cd11cfec2bdcfR1-R80): Parses user commands and maps them to appropriate execution types (`ExecType`). Handles path and argument processing for directory-related commands. (`[src/main/java/home/example/echoLog/util/CommandParser.javaR1-R80](diffhunk://#diff-e73f81ae4b7c9f296dfa80d6e10829a8e5bf73469ff5f8b41f8cd11cfec2bdcfR1-R80)`)

### Models and DTOs

* **Models**:
  * [`Directory`](diffhunk://#diff-72501ad5807c061f280b59c0354df22906c41d3656b0efc0ea0bb18939520df1R1-R15): Represents a directory with fields like `dir_id`, `name`, `parent_id`, and `created_at`. (`[src/main/java/home/example/echoLog/model/Directory.javaR1-R15](diffhunk://#diff-72501ad5807c061f280b59c0354df22906c41d3656b0efc0ea0bb18939520df1R1-R15)`)
  * [`EchoLog`](diffhunk://#diff-b4a6669b23fd846e5cd5d2f1f92ec60b7ec00c9a3837bb94323f3f00abb3dd94R1-R13): Represents a log entry with fields like `log_seq`, `dir_id`, `message`, and `created_at`. (`[src/main/java/home/example/echoLog/model/EchoLog.javaR1-R13](diffhunk://#diff-b4a6669b23fd846e5cd5d2f1f92ec60b7ec00c9a3837bb94323f3f00abb3dd94R1-R13)`)

* **DTOs**:
  * [`CommandRequestDTO`](diffhunk://#diff-253f9e110d337e68d1051e92b262df03278036a86a68107bdef22cb26129be81R1-R9): Represents the request payload for the `/api/cmd` endpoint, containing `path` and `command`. (`[src/main/java/home/example/echoLog/model/dto/CommandRequestDTO.javaR1-R9](diffhunk://#diff-253f9e110d337e68d1051e92b262df03278036a86a68107bdef22cb26129be81R1-R9)`)

* **Enums**:
  * [`ExecType`](diffhunk://#diff-f293a77d517785c004186c90df2b6ba8e16e10cb63adabdbecdf4eb9a532887cR1-R14): Defines execution types (`ECHO`, `MKDIR`, `CD`, `LS`, `TREE`) for command parsing and execution. (`[src/main/java/home/example/echoLog/model/type/ExecType.javaR1-R14](diffhunk://#diff-f293a77d517785c004186c90df2b6ba8e16e10cb63adabdbecdf4eb9a532887cR1-R14)`)

### Database Integration

* **`DirectoryMapper`**: Added MyBatis mapper interface for directory-related database operations, including retrieving directories by name or ID, adding new directories, and fetching child directories. (`[src/main/java/home/example/echoLog/mapper/DirectoryMapper.javaR1-R16](diffhunk://#diff-dbccc8362d9b66e2ea2abc7dccecc20d04db5e9337c7ccc74f899851c70dc3e0R1-R16)`)
* **SQL Mapper Configuration**: Added MyBatis XML configuration for `DirectoryMapper` to define SQL queries for directory operations. (`[src/main/resources/mapper/directoryMapper.xmlR1-R45](diffhunk://#diff-ffd4c8f442fd05002629d3c05f8e99c7dc589220d1cf115f508d0f46fdba0fdfR1-R45)`) 

These changes collectively implement a foundation for handling directory and log-related commands in a structured and extensible way.