### PR TITLE
add initial HTML and JavaScript for terminal log interface

### DIFF
--- a/src/main/java/home/example/echoLog/controller/page/PageController.java
+++ b/src/main/java/home/example/echoLog/controller/page/PageController.java
@@ -1,0 +1,13 @@
+package home.example.echoLog.controller.page;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class PageController {
+
+    @GetMapping("/")
+    public String index() {
+        return "index"; // This should return the name of the HTML file in your templates directory
+    }
+}

--- a/src/main/java/home/example/echoLog/model/EchoLog.java
+++ b/src/main/java/home/example/echoLog/model/EchoLog.java
@@ -1,14 +1,12 @@
 package home.example.echoLog.model;
 
 import lombok.Builder;
-import lombok.NoArgsConstructor;
 import lombok.Data;
 
 import java.time.LocalDateTime;
 
 @Data
 @Builder
-@NoArgsConstructor
 public class EchoLog {
     private Long log_seq;
     private Long dir_id;

--- a/src/main/resources/static/js/index.js
+++ b/src/main/resources/static/js/index.js
@@ -1,0 +1,58 @@
+(function() {
+    let logs;
+    let input;
+    let pathElem;
+    let currentPath = '/';
+    let theme = 'dark';
+
+    document.addEventListener( 'DOMContentLoaded', function() {
+        echoLogs.init();
+    });
+
+    let echoLogs = {
+        init : function () {
+            console.log( 'Echo Logs Initialized' );
+
+            logs = document.getElementById('logs');
+            input = document.getElementById('cmdInput');
+            pathElem = document.getElementById('currentPath');
+            currentPath = '/';
+            theme = 'dark';
+
+            echoLogs.bindInputEvents();
+        },
+        bindInputEvents : function() {
+            input.focus();
+            input.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter') {
+                    const cmd = input.value.trim();
+                    input.value = '';
+
+                    if (cmd.startsWith('/')) {
+                        echoLogs.handleCommand(cmd);
+                    } else {
+                        echoLogs.appendLog(`[${new Date().toLocaleTimeString()}] ${cmd}`);
+                        // TODO: POST to /api/log
+                    }
+                }
+            });
+        },
+        handleCommand : function(cmd) {
+            if (cmd === '/light') {
+                document.body.classList.add('light');
+                theme = 'light';
+                appendLog('> light mode on');
+            } else if (cmd === '/dark') {
+                document.body.classList.remove('light');
+                theme = 'dark';
+                appendLog('> dark mode on');
+            } else if (cmd === '/help') {
+                appendLog('> commands: /cd /light /dark /ls /mkdir /pwd /tree /echo /help');
+            }
+        },
+        appendLog : function(cmd) {
+            logs.textContent += `\n${text}`;
+            logs.scrollTop = logs.scrollHeight;
+        }
+    }
+})();

--- a/src/main/resources/static/js/index.js
+++ b/src/main/resources/static/js/index.js
@@ -41,17 +41,17 @@
             if (cmd === '/light') {
                 document.body.classList.add('light');
                 theme = 'light';
-                appendLog('> light mode on');
+                echoLogs.appendLog('> light mode on');
             } else if (cmd === '/dark') {
                 document.body.classList.remove('light');
                 theme = 'dark';
-                appendLog('> dark mode on');
+                echoLogs.appendLog('> dark mode on');
             } else if (cmd === '/help') {
-                appendLog('> commands: /cd /light /dark /ls /mkdir /pwd /tree /echo /help');
+                echoLogs.appendLog('> commands: /cd /light /dark /ls /mkdir /pwd /tree /echo /help');
             }
         },
         appendLog : function(cmd) {
-            logs.textContent += `\n${text}`;
+            logs.textContent += `\n${cmd}`;
             logs.scrollTop = logs.scrollHeight;
         }
     }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" th:charset="UTF-8"/>
+    <title>Terminal Log</title>
+    <style>
+        body {
+            background: #000;
+            color: #0f0;
+            font-family: monospace;
+            padding: 20px;
+        }
+        .terminal {
+            max-width: 800px;
+            margin: auto;
+        }
+        .logs {
+            max-height: 70vh;
+            overflow-y: auto;
+            white-space: pre-wrap;
+            margin-bottom: 20px;
+            border: 1px solid #0f0;
+            padding: 10px;
+        }
+        .input-line {
+            display: flex;
+            align-items: center;
+        }
+        .current-path {
+            font-weight: bold;
+            color: #0f0;
+        }
+        input {
+            background: transparent;
+            border: none;
+            color: #0f0;
+            flex: 1;
+            font-family: monospace;
+            font-size: 16px;
+            outline: none;
+        }
+        .light {
+            background: #eee;
+            color: #111;
+        }
+        .light .current-path,
+        .light input {
+            color: #111;
+        }
+    </style>
+</head>
+<body>
+<div class="terminal" id="terminal">
+    <div class="logs" id="logs">
+        [12:01] welcome to the echo world.
+    </div>
+    <div class="input-line">
+        <span class="current-path" id="currentPath">/</span>&nbsp;&gt;&nbsp;
+        <input type="text" id="cmdInput" autocomplete="off" />
+    </div>
+</div>
+
+<script th:src="${/js/index.js}"></script>
+</body>
+</html>


### PR DESCRIPTION
This pull request introduces a basic terminal-style logging web application. It includes changes to add a `PageController` for handling the root route, a new `index.html` template for the terminal UI, and a JavaScript file to handle user interaction and commands. Additionally, a minor adjustment was made to the `EchoLog` model.

### Backend Changes:
* **Added `PageController`**: A new Spring Controller (`PageController`) was added to handle the root route (`/`) and return the `index.html` template. (`src/main/java/home/example/echoLog/controller/page/PageController.java`)

* **Updated `EchoLog` model**: Removed the `@NoArgsConstructor` annotation from the `EchoLog` class, leaving only the `@Builder` annotation for object creation. (`src/main/java/home/example/echoLog/model/EchoLog.java`)

### Frontend Changes:
* **Created `index.html` template**: Added a terminal-style UI with a dark theme, styled using inline CSS. The page includes a log display area and an input field for commands. It also supports a light mode toggle. (`src/main/resources/templates/index.html`)

* **Added `index.js` script**: Implemented JavaScript to initialize the terminal, handle user input, and process commands such as `/light`, `/dark`, and `/help`. Commands are logged to the terminal, and placeholders are included for future API integration. (`src/main/resources/static/js/index.js`)