### PR TITLE
add deployment workflow for echo log project using GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,20 @@
+name: Deploy echo log project
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: self-hosted
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Build Docker Image
+        run: docker build --build-arg ACTIVE_PROFILE=dev -t echo-log:latest .
+
+      - name: Deploy Docker Container
+        run: docker compose -f /Users/hoonzi/Documents/docker_v/docker-compose.yml up -d


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the deployment of the "echo log" project. The workflow is triggered on pushes to the `main` branch or manually via `workflow_dispatch`.

### New Deployment Workflow:

* `.github/workflows/deploy.yml`: Added a workflow named "Deploy echo log project" that:
  - Checks out the repository using the `actions/checkout` action.  
  - Builds a Docker image with the `ACTIVE_PROFILE` set to `dev`.  
  - Deploys the Docker container using a specified `docker-compose.yml` file.