### PR TITLE
add DeleteLogService

### DIFF
--- a/src/main/java/home/example/echoLog/mapper/EchoLogMapper.java
+++ b/src/main/java/home/example/echoLog/mapper/EchoLogMapper.java
@@ -12,4 +12,5 @@ import java.util.Optional;
 public interface EchoLogMapper {
     void insertEchoLog(EchoLog echoLog);
     List<EchoLog> getEchoLogByDirId(HistoryRequestDTO historyRequestDTO);
+    void deleteLogByDate();
 }

--- a/src/main/java/home/example/echoLog/service/DeleteLogService.java
+++ b/src/main/java/home/example/echoLog/service/DeleteLogService.java
@@ -16,6 +16,7 @@ public class DeleteLogService {
     }
 
     @Scheduled(cron = "0 0 * * * *")
+    @Transactional
     public void purgeLogs() {
         try {
             echoLogMapper.deleteLogByDate();

--- a/src/main/java/home/example/echoLog/service/DeleteLogService.java
+++ b/src/main/java/home/example/echoLog/service/DeleteLogService.java
@@ -1,0 +1,27 @@
+package home.example.echoLog.service;
+
+import home.example.echoLog.mapper.EchoLogMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+public class DeleteLogService {
+
+    private final EchoLogMapper echoLogMapper;
+    public DeleteLogService(EchoLogMapper echoLogMapper) {
+        this.echoLogMapper = echoLogMapper;
+    }
+
+    @Scheduled(cron = "0 0 * * * *")
+    public void purgeLogs() {
+        try {
+            echoLogMapper.deleteLogByDate();
+        } catch (Exception e) {
+            // Handle the exception, log it, or rethrow it as needed
+            log.error("Error occurred while deleting logs: ", e);
+        }
+    }
+}

--- a/src/main/resources/mapper/echoLogMapper.xml
+++ b/src/main/resources/mapper/echoLogMapper.xml
@@ -20,4 +20,11 @@
                 order by created_at DESC
                 limit #{limit}
         </select>
+
+        <delete id="deleteLogByDate">
+            <![CDATA[
+                DELETE FROM echo_logs
+                WHERE created_at < NOW() - INTERVAL 7 DAY
+            ]]>
+        </delete>
     </mapper>


### PR DESCRIPTION
periodically purge old logs and update EchoLogMapper for log deletion

This pull request introduces a new feature to automatically delete old logs from the database. The changes include adding a scheduled service to handle log purging, updating the mapper interface and XML to support the deletion operation, and ensuring proper error handling during the scheduled task.

### New log deletion feature:

* **Mapper interface update**: Added a new method `deleteLogByDate` to the `EchoLogMapper` interface to support log deletion by date. (`src/main/java/home/example/echoLog/mapper/EchoLogMapper.java`)

* **Scheduled service implementation**: Introduced a new `DeleteLogService` class that uses the `@Scheduled` annotation to automatically invoke the `deleteLogByDate` method on an hourly basis. The service includes error handling to log any exceptions that occur during the deletion process. (`src/main/java/home/example/echoLog/service/DeleteLogService.java`)

* **SQL mapper update**: Added a new SQL `DELETE` operation in `echoLogMapper.xml` to remove logs older than 7 days. (`src/main/resources/mapper/echoLogMapper.xml`)